### PR TITLE
Allow disabling of cleaning up

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Note that the following values will be overwritten to ensure isolation:
 * `$conf["file_private_path"]`
 * `$conf["file_temporary_path"]`
 
+### `clean_up`
+
+By default, the extension will remove the sites it created after the suite has finished. If you're running the suite a few times in quick succession, this means it will be installing a site each time, which can be quite slow. Setting this value to `false` (the default is `true`) which cause it *not* clean up the filesystem, so the second (and subsequent) runs will use the copy of the installed site from the first run. This will be quicker, but it's up to the developer to make sure that no changes have been made to the install process (if required, the master site will need to be manually removed).
+
 Running the extension's tests
 -----------------------------
 

--- a/src/Filesystem/NoOpFilesystemCleaner.php
+++ b/src/Filesystem/NoOpFilesystemCleaner.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace eLife\IsolatedDrupalBehatExtension\Filesystem;
+
+final class NoOpFilesystemCleaner implements FilesystemCleaner
+{
+    public function register($path)
+    {
+        // Do nothing.
+    }
+}

--- a/src/ServiceContainer/Compiler/FilesystemCleanerCompilerPass.php
+++ b/src/ServiceContainer/Compiler/FilesystemCleanerCompilerPass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace eLife\IsolatedDrupalBehatExtension\ServiceContainer\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface as CompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class FilesystemCleanerCompilerPass implements CompilerPass
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasParameter('elife_drupal_behat.clean_up')) {
+            return;
+        }
+
+        if (false === $container->getParameter('elife_drupal_behat.clean_up')) {
+            $container->getDefinition('elife.isolated_drupal_behat.filesystem_cleaner.symfony')
+                ->setDecoratedService(null);
+            $container->getDefinition('elife.isolated_drupal_behat.filesystem_cleaner.no_op')
+                ->setDecoratedService('elife.isolated_drupal_behat.filesystem_cleaner');
+        }
+    }
+}

--- a/src/ServiceContainer/IsolatedDrupalBehatExtension.php
+++ b/src/ServiceContainer/IsolatedDrupalBehatExtension.php
@@ -4,8 +4,10 @@ namespace eLife\IsolatedDrupalBehatExtension\ServiceContainer;
 
 use Behat\Testwork\ServiceContainer\Extension as TestworkExtension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
+use eLife\IsolatedDrupalBehatExtension\ServiceContainer\Compiler\FilesystemCleanerCompilerPass;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface as CompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
@@ -13,6 +15,9 @@ final class IsolatedDrupalBehatExtension implements TestworkExtension
 {
     public function process(ContainerBuilder $container)
     {
+        foreach ($this->getCompilerPasses() as $compilerPass) {
+            $compilerPass->process($container);
+        }
     }
 
     public function getConfigKey()
@@ -32,6 +37,7 @@ final class IsolatedDrupalBehatExtension implements TestworkExtension
                     ->scalarNode('db_url')->isRequired()->end()
                     ->scalarNode('profile')->defaultValue('standard')->end()
                     ->scalarNode('settings_file')->defaultNull()->end()
+                    ->booleanNode('clean_up')->defaultTrue()->end()
                 ->end()
             ->end();
     }
@@ -62,5 +68,17 @@ final class IsolatedDrupalBehatExtension implements TestworkExtension
             'elife_drupal_behat.settings_file',
             $config['settings_file']
         );
+        $container->setParameter(
+            'elife_drupal_behat.clean_up',
+            $config['clean_up']
+        );
+    }
+
+    /**
+     * @return CompilerPass[]
+     */
+    public function getCompilerPasses()
+    {
+        return [new FilesystemCleanerCompilerPass()];
     }
 }

--- a/src/ServiceContainer/config/filesystem.yml
+++ b/src/ServiceContainer/config/filesystem.yml
@@ -10,3 +10,7 @@ services:
     public: false
     arguments:
       - @elife.isolated_drupal_behat.symfony_filesystem
+
+  elife.isolated_drupal_behat.filesystem_cleaner.no_op:
+    class: eLife\IsolatedDrupalBehatExtension\Filesystem\NoOpFilesystemCleaner
+    public: false

--- a/tests/Filesystem/FilesystemCleanerTest.php
+++ b/tests/Filesystem/FilesystemCleanerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace eLife\IsolatedDrupalBehatExtension\Filesystem;
+
+use eLife\IsolatedDrupalBehatExtension\TestCase;
+use org\bovigo\vfs\vfsStream;
+
+abstract class FilesystemCleanerTest extends TestCase
+{
+    final protected function createFilesystem($name)
+    {
+        return vfsStream::setup($name);
+    }
+
+    final protected function createDirectory($path)
+    {
+        return vfsStream::newDirectory($path);
+    }
+
+    final protected function createFile($path)
+    {
+        $file = vfsStream::newFile($path);
+        $file->setContent($path);
+
+        return $file;
+    }
+}

--- a/tests/Filesystem/SymfonyFilesystemCleanerTest.php
+++ b/tests/Filesystem/SymfonyFilesystemCleanerTest.php
@@ -2,11 +2,9 @@
 
 namespace eLife\IsolatedDrupalBehatExtension\Filesystem;
 
-use eLife\IsolatedDrupalBehatExtension\TestCase;
-use org\bovigo\vfs\vfsStream;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class SymfonyFilesystemCleanerTest extends TestCase
+final class SymfonyFilesystemCleanerTest extends FilesystemCleanerTest
 {
     /**
      * @test
@@ -15,7 +13,7 @@ final class SymfonyFilesystemCleanerTest extends TestCase
     {
         $cleaner = new SymfonyFilesystemCleaner(new Filesystem());
 
-        $root = vfsStream::setup('foo');
+        $root = $this->createFilesystem('foo');
 
         $root->addChild($dir = $this->createDirectory('bar'));
         $cleaner->register($dir->url());
@@ -31,18 +29,5 @@ final class SymfonyFilesystemCleanerTest extends TestCase
 
         $this->assertCount(1, $root->getChildren());
         $this->assertTrue($root->hasChild('other'));
-    }
-
-    private function createDirectory($path)
-    {
-        return vfsStream::newDirectory($path);
-    }
-
-    private function createFile($path)
-    {
-        $file = vfsStream::newFile($path);
-        $file->setContent($path);
-
-        return $file;
     }
 }

--- a/tests/ServiceContainer/Compiler/FilesystemCleanerCompilerPassTest.php
+++ b/tests/ServiceContainer/Compiler/FilesystemCleanerCompilerPassTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace eLife\IsolatedDrupalBehatExtension\ServiceContainer;
+
+use eLife\IsolatedDrupalBehatExtension\ServiceContainer\Compiler\FilesystemCleanerCompilerPass;
+use eLife\IsolatedDrupalBehatExtension\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+final class FilesystemCleanerCompilerPassTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itCleansTheFilesystem()
+    {
+        $compilerPass = new FilesystemCleanerCompilerPass();
+
+        $container = $this->getContainer(true);
+
+        $compilerPass->process($container);
+
+        $container->compile();
+
+        $this->assertInstanceOf(
+            'eLife\IsolatedDrupalBehatExtension\Filesystem\SymfonyFilesystemCleaner',
+            $container->get('elife.isolated_drupal_behat.filesystem_cleaner')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itDoesNotCleanTheFilesystem()
+    {
+        $compilerPass = new FilesystemCleanerCompilerPass();
+
+        $container = $this->getContainer(false);
+
+        $compilerPass->process($container);
+
+        $container->compile();
+
+        $this->assertInstanceOf(
+            'eLife\IsolatedDrupalBehatExtension\Filesystem\NoOpFilesystemCleaner',
+            $container->get('elife.isolated_drupal_behat.filesystem_cleaner')
+        );
+    }
+
+    private function getContainer($cleanUp)
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('elife_drupal_behat.clean_up', $cleanUp);
+
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../../../src/ServiceContainer/config')
+        );
+
+        $loader->load('filesystem.yml');
+
+        $container->setDefinition(
+            'elife.isolated_drupal_behat.symfony_filesystem',
+            new Definition('Symfony\Component\Filesystem\Filesystem')
+        );
+
+        return $container;
+    }
+}

--- a/tests/ServiceContainer/IsolatedDrupalBehatExtensionTest.php
+++ b/tests/ServiceContainer/IsolatedDrupalBehatExtensionTest.php
@@ -65,6 +65,7 @@ final class IsolatedDrupalBehatExtensionTest extends TestCase
                     'db_url' => 'mysql://localhost/db',
                     'profile' => 'standard',
                     'settings_file' => null,
+                    'clean_up' => true,
                 ],
             ],
             [
@@ -72,11 +73,13 @@ final class IsolatedDrupalBehatExtensionTest extends TestCase
                     'db_url' => 'mysql://localhost/db',
                     'profile' => 'foo',
                     'settings_file' => __FILE__,
+                    'clean_up' => false,
                 ],
                 [
                     'db_url' => 'mysql://localhost/db',
                     'profile' => 'foo',
                     'settings_file' => __FILE__,
+                    'clean_up' => false,
                 ],
             ],
         ];
@@ -97,6 +100,7 @@ final class IsolatedDrupalBehatExtensionTest extends TestCase
                 'db_url' => $dbUrl = 'mysql://localhost/db',
                 'profile' => $profile = 'standard',
                 'settings_file' => $settingsFile = null,
+                'clean_up' => $cleanUp = true,
             ]
         );
 
@@ -111,6 +115,10 @@ final class IsolatedDrupalBehatExtensionTest extends TestCase
         $this->assertSame(
             $settingsFile,
             $container->getParameter('elife_drupal_behat.settings_file')
+        );
+        $this->assertSame(
+            $cleanUp,
+            $container->getParameter('elife_drupal_behat.clean_up')
         );
     }
 }


### PR DESCRIPTION
When running the suite a few times in quick succession for some reason it would be useful for the extension to _not_ remove the master site at the end of the suite to speed it up.

This does mean that the user will have to keep track of whether they need to remove it manually or not.
