### PR TITLE
Remove Drush timeout

### DIFF
--- a/src/Listener/BypassInstallSiteListener.php
+++ b/src/Listener/BypassInstallSiteListener.php
@@ -116,7 +116,7 @@ final class BypassInstallSiteListener implements EventSubscriber
                 ->add('sql-drop')
                 ->add('--yes')
                 ->setWorkingDirectory($this->drupal->getSitePath())
-                ->setTimeout(600)
+                ->setTimeout(null)
                 ->getProcess()
         );
 
@@ -128,7 +128,7 @@ final class BypassInstallSiteListener implements EventSubscriber
                 ->add('--file=' . $this->drupal->getSitePath() . '/db.sql')
                 ->add('--yes')
                 ->setWorkingDirectory($this->drupal->getSitePath())
-                ->setTimeout(600)
+                ->setTimeout(null)
                 ->getProcess()
         );
         $this->filesystem->remove($this->drupal->getSitePath() . '/db.sql');
@@ -164,7 +164,7 @@ final class BypassInstallSiteListener implements EventSubscriber
                 ->add('--result-file=' . $this->masterPath . '/db.sql')
                 ->add('--yes')
                 ->setWorkingDirectory($this->drupal->getSitePath())
-                ->setTimeout(600)
+                ->setTimeout(null)
                 ->getProcess()
         );
     }

--- a/src/Listener/InstallSiteListener.php
+++ b/src/Listener/InstallSiteListener.php
@@ -74,7 +74,7 @@ final class InstallSiteListener implements EventSubscriber
             ->add('--account-pass=password')
             ->add('--yes')
             ->setWorkingDirectory($this->drupal->getSitePath())
-            ->setTimeout(600)
+            ->setTimeout(null)
             ->setEnv('PHP_OPTIONS', '-d sendmail_path=' . `which true`);
 
         $this->eventDispatcher->dispatch(


### PR DESCRIPTION
It's possible that a Drush `site-install` might take longer than 10 minutes, so the timeout needs removing.

I did think about making it a setting instead, but it's easier to trust Drush to not get stuck.
