### PR TITLE
Scenario outline examples aren't isolated

### DIFF
--- a/features/drupal7.feature
+++ b/features/drupal7.feature
@@ -119,3 +119,73 @@ Feature: Isolated Drupal 7 runs
             3 scenarios (3 passed)
             7 steps (7 passed)
             """
+
+    Scenario: Scenario outline examples run in isolation from each other
+        Given a file named "behat.yml" with:
+            """
+            default:
+                suites:
+                    default:
+                        contexts:
+                          - FeatureContext: ~
+                          - Behat\MinkExtension\Context\MinkContext: ~
+                          - Drupal\DrupalExtension\Context\DrupalContext: ~
+                extensions:
+                    Behat\MinkExtension:
+                        goutte: ~
+                        base_url: '{{ base_url }}'
+                    Drupal\DrupalExtension:
+                        blackbox: ~
+                        api_driver: 'drupal'
+                        drush:
+                            binary: '{{ drush }}'
+                            root: '{{ drupal_root }}'
+                        drupal:
+                            drupal_root: '{{ drupal_root }}'
+                    eLife\IsolatedDrupalBehatExtension:
+                        db_url: '{{ db_url }}'
+            """
+        And a file named "features/bootstrap/FeatureContext.php" with:
+            """
+            <?php
+
+            use Behat\Behat\Context\Context;
+
+            class FeatureContext implements Context
+            {
+                /**
+                 * @When the :arg1 variable is set to :arg2
+                 */
+                public function theVariableIsSetTo($variable, $value)
+                {
+                    variable_set($variable, $value);
+                }
+            }
+            """
+        And a file named "features/client.feature" with:
+            """
+            Feature: Setting the site name
+                In order to understand what site I am on
+                As a website user
+                I need to be able to see the site name
+
+            Scenario Outline: Default name is Set
+                When I go to the homepage
+                Then I should see "Site-Install" in the "#name-and-slogan" element
+                When the "site_name" variable is set to "<name>"
+                And I go to the homepage
+                Then I should see "<name>" in the "#name-and-slogan" element
+
+            Examples:
+                | name |
+                | Foo  |
+                | Bar  |
+            """
+        When I run "behat --format progress features/client.feature"
+        Then it should pass with:
+            """
+            ..........
+
+            2 scenarios (2 passed)
+            10 steps (10 passed)
+            """

--- a/src/Listener/InstallSiteListener.php
+++ b/src/Listener/InstallSiteListener.php
@@ -2,9 +2,9 @@
 
 namespace eLife\IsolatedDrupalBehatExtension\Listener;
 
-use Behat\Behat\EventDispatcher\Event\BeforeOutlineTested;
-use Behat\Behat\EventDispatcher\Event\BeforeScenarioTested;
-use Behat\Testwork\EventDispatcher\Event\BeforeSuiteTested;
+use Behat\Behat\EventDispatcher\Event\ExampleTested;
+use Behat\Behat\EventDispatcher\Event\ScenarioTested;
+use Behat\Testwork\EventDispatcher\Event\SuiteTested;
 use eLife\IsolatedDrupalBehatExtension\Drupal;
 use eLife\IsolatedDrupalBehatExtension\Event\InstallingSite;
 use eLife\IsolatedDrupalBehatExtension\Event\SiteInstalled;
@@ -39,9 +39,9 @@ final class InstallSiteListener implements EventSubscriber
     {
         return [
             // Drupal extension will try and bootstrap at the beginning of the suite.
-            BeforeSuiteTested::BEFORE => ['onBeforeScenarioTested', 255],
-            BeforeScenarioTested::BEFORE => ['onBeforeScenarioTested', 255],
-            BeforeOutlineTested::BEFORE => ['onBeforeScenarioTested', 255],
+            SuiteTested::BEFORE => ['onBeforeScenarioTested', 255],
+            ScenarioTested::BEFORE => ['onBeforeScenarioTested', 255],
+            ExampleTested::BEFORE => ['onBeforeScenarioTested', 255],
         ];
     }
 


### PR DESCRIPTION
The wrong event is used (`OutlineTested::BEFORE` rather than `ExampleTested::BEFORE`), so the scenario outline is isolated rather than each example.
