### PR TITLE
Remove an existing master copy before the suite is run

### DIFF
--- a/src/Filesystem/FilesystemCleaner.php
+++ b/src/Filesystem/FilesystemCleaner.php
@@ -5,7 +5,7 @@ namespace eLife\IsolatedDrupalBehatExtension\Filesystem;
 interface FilesystemCleaner
 {
     /**
-     * @param string $path
+     * @param string[] $paths
      */
-    public function register($path);
+    public function clean(array $paths);
 }

--- a/src/Filesystem/InMemoryLazyFilesystemCleaner.php
+++ b/src/Filesystem/InMemoryLazyFilesystemCleaner.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace eLife\IsolatedDrupalBehatExtension\Filesystem;
+
+final class InMemoryLazyFilesystemCleaner implements LazyFilesystemCleaner
+{
+    /**
+     * @var FilesystemCleaner
+     */
+    private $filesystemCleaner;
+
+    /**
+     * @var string[]
+     */
+    private $toClean = [];
+
+    /**
+     * @param FilesystemCleaner $filesystem
+     */
+    public function __construct(FilesystemCleaner $filesystem)
+    {
+        $this->filesystemCleaner = $filesystem;
+    }
+
+    public function register($path)
+    {
+        $this->toClean[] = $path;
+    }
+
+    public function cleanRegistered()
+    {
+        $this->filesystemCleaner->clean(array_values(array_unique($this->toClean)));
+        $this->toClean = [];
+    }
+}

--- a/src/Filesystem/LazyFilesystemCleaner.php
+++ b/src/Filesystem/LazyFilesystemCleaner.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace eLife\IsolatedDrupalBehatExtension\Filesystem;
+
+interface LazyFilesystemCleaner
+{
+    /**
+     * @param string $path
+     */
+    public function register($path);
+
+    public function cleanRegistered();
+}

--- a/src/Filesystem/NoOpFilesystemCleaner.php
+++ b/src/Filesystem/NoOpFilesystemCleaner.php
@@ -4,7 +4,7 @@ namespace eLife\IsolatedDrupalBehatExtension\Filesystem;
 
 final class NoOpFilesystemCleaner implements FilesystemCleaner
 {
-    public function register($path)
+    public function clean(array $paths)
     {
         // Do nothing.
     }

--- a/src/Filesystem/SymfonyFilesystemCleaner.php
+++ b/src/Filesystem/SymfonyFilesystemCleaner.php
@@ -12,32 +12,15 @@ final class SymfonyFilesystemCleaner implements FilesystemCleaner
     private $filesystem;
 
     /**
-     * @var string[]
-     */
-    private $toClean = [];
-
-    /**
      * @param Filesystem $filesystem
      */
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;
-
-        // @codeCoverageIgnoreStart
-        register_shutdown_function(function () {
-            $this->clean();
-        });
-        // @codeCoverageIgnoreEnd
     }
 
-    public function register($path)
+    public function clean(array $paths)
     {
-        $this->toClean[] = $path;
-    }
-
-    public function clean()
-    {
-        $this->filesystem->remove(array_unique($this->toClean));
-        $this->toClean = [];
+        $this->filesystem->remove(array_unique($paths));
     }
 }

--- a/src/ServiceContainer/config/filesystem.yml
+++ b/src/ServiceContainer/config/filesystem.yml
@@ -14,3 +14,14 @@ services:
   elife.isolated_drupal_behat.filesystem_cleaner.no_op:
     class: eLife\IsolatedDrupalBehatExtension\Filesystem\NoOpFilesystemCleaner
     public: false
+
+  elife.isolated_drupal_behat.lazy_filesystem_cleaner:
+    class: eLife\IsolatedDrupalBehatExtension\Filesystem\LazyFilesystemCleaner
+    abstract: true
+
+  elife.isolated_drupal_behat.lazy_filesystem_cleaner.in_memory:
+    class: eLife\IsolatedDrupalBehatExtension\Filesystem\InMemoryLazyFilesystemCleaner
+    decorates: elife.isolated_drupal_behat.lazy_filesystem_cleaner
+    public: false
+    arguments:
+      - @elife.isolated_drupal_behat.filesystem_cleaner

--- a/src/ServiceContainer/config/listeners.yml
+++ b/src/ServiceContainer/config/listeners.yml
@@ -19,13 +19,14 @@ services:
       - %drupal.driver.drush.binary%
       - @elife.isolated_drupal_behat.process_runner
       - @elife.isolated_drupal_behat.filesystem_cleaner
+      - @elife.isolated_drupal_behat.lazy_filesystem_cleaner
     tags:
       - { name: event_dispatcher.subscriber }
 
   elife.isolated_drupal_behat.listener.cleaner:
     class: eLife\IsolatedDrupalBehatExtension\Listener\CleanerListener
     arguments:
-      - @elife.isolated_drupal_behat.filesystem_cleaner
+      - @elife.isolated_drupal_behat.lazy_filesystem_cleaner
     tags:
       - { name: event_dispatcher.subscriber }
 

--- a/tests/Filesystem/InMemoryLazyFilesystemCleanerTest.php
+++ b/tests/Filesystem/InMemoryLazyFilesystemCleanerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace eLife\IsolatedDrupalBehatExtension\Filesystem;
+
+use eLife\IsolatedDrupalBehatExtension\TestCase;
+
+final class InMemoryLazyFilesystemCleanerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itCleansPaths()
+    {
+        $filesystemCleaner = $this->prophesize('eLife\IsolatedDrupalBehatExtension\Filesystem\FilesystemCleaner');
+
+        $cleaner = new InMemoryLazyFilesystemCleaner($filesystemCleaner->reveal());
+
+        $cleaner->register('/foo');
+        $cleaner->register('/foo');
+        $cleaner->register('/bar');
+
+        $filesystemCleaner->clean(['/foo', '/bar'])->shouldBeCalled();
+
+        $cleaner->cleanRegistered();
+    }
+}

--- a/tests/Filesystem/NoOpFilesystemCleanerTest.php
+++ b/tests/Filesystem/NoOpFilesystemCleanerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace eLife\IsolatedDrupalBehatExtension\Filesystem;
+
+final class NoOpFilesystemCleanerTest extends FilesystemCleanerTest
+{
+    /**
+     * @test
+     */
+    public function itDoesNotCleanPaths()
+    {
+        $cleaner = new NoOpFilesystemCleaner();
+
+        $root = $this->createFilesystem('foo');
+
+        $root->addChild($child = $this->createDirectory('bar'));
+
+        $cleaner->clean([$child->url()]);
+
+        $this->assertCount(1, $root->getChildren());
+        $this->assertTrue($root->hasChild('bar'));
+    }
+}

--- a/tests/Filesystem/SymfonyFilesystemCleanerTest.php
+++ b/tests/Filesystem/SymfonyFilesystemCleanerTest.php
@@ -15,19 +15,14 @@ final class SymfonyFilesystemCleanerTest extends FilesystemCleanerTest
 
         $root = $this->createFilesystem('foo');
 
-        $root->addChild($dir = $this->createDirectory('bar'));
-        $cleaner->register($dir->url());
-        $dir->addChild($dirFile = $this->createFile('baz'));
-        $cleaner->register($dirFile->url());
-        $root->addChild($emptyDir = $this->createDirectory('qux'));
-        $cleaner->register($root->url() . '/qux');
-        $root->addChild($file = $this->createFile('quxx'));
-        $cleaner->register($file->url());
-        $root->addChild($file = $this->createFile('other'));
+        $root->addChild($child1 = $this->createDirectory('bar'));
+        $child1->addChild($this->createFile('baz'));
+        $root->addChild($this->createDirectory('qux'));
+        $root->addChild($child3 = $this->createDirectory('quxx'));
 
-        $cleaner->clean();
+        $cleaner->clean([$child1->url(), $child3->url()]);
 
         $this->assertCount(1, $root->getChildren());
-        $this->assertTrue($root->hasChild('other'));
+        $this->assertTrue($root->hasChild('qux'));
     }
 }

--- a/tests/Listener/CleanerListenerTest.php
+++ b/tests/Listener/CleanerListenerTest.php
@@ -2,6 +2,13 @@
 
 namespace eLife\IsolatedDrupalBehatExtension\Listener;
 
+use Behat\Testwork\Environment\StaticEnvironment;
+use Behat\Testwork\EventDispatcher\Event\AfterSuiteTested;
+use Behat\Testwork\EventDispatcher\Event\SuiteTested;
+use Behat\Testwork\Specification\NoSpecificationsIterator;
+use Behat\Testwork\Suite\GenericSuite;
+use Behat\Testwork\Tester\Result\IntegerTestResult;
+use Behat\Testwork\Tester\Setup\SuccessfulTeardown;
 use eLife\IsolatedDrupalBehatExtension\Drupal;
 use eLife\IsolatedDrupalBehatExtension\Event\InstallingSite;
 use eLife\IsolatedDrupalBehatExtension\Event\SiteCloned;
@@ -23,7 +30,7 @@ final class CleanerListenerTest extends ListenerTest
     ) {
         vfsStream::setup('foo');
 
-        $cleaner = $this->prophesize('eLife\IsolatedDrupalBehatExtension\Filesystem\FilesystemCleaner');
+        $cleaner = $this->prophesize('eLife\IsolatedDrupalBehatExtension\Filesystem\LazyFilesystemCleaner');
 
         $listener = new CleanerListener($cleaner->reveal());
         $dispatcher = $this->getDispatcher($listener);
@@ -33,6 +40,8 @@ final class CleanerListenerTest extends ListenerTest
         foreach ($toClean as $path => $times) {
             $cleaner->register($path)->shouldHaveBeenCalledTimes($times);
         }
+
+        $cleaner->cleanRegistered()->willReturn();
     }
 
     public function eventProvider()
@@ -56,5 +65,30 @@ final class CleanerListenerTest extends ListenerTest
                 [$drupal->getSitePath() => 1],
             ],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function itClearsRegisteredPathsAfterTheSuiteIsRun()
+    {
+        $cleaner = $this->prophesize('eLife\IsolatedDrupalBehatExtension\Filesystem\LazyFilesystemCleaner');
+
+        $listener = new CleanerListener($cleaner->reveal());
+        $dispatcher = $this->getDispatcher($listener);
+
+        $suite = new GenericSuite('foo', []);
+
+        $dispatcher->dispatch(
+            SuiteTested::AFTER,
+            new AfterSuiteTested(
+                new StaticEnvironment($suite),
+                new NoSpecificationsIterator($suite),
+                new IntegerTestResult(1),
+                new SuccessfulTeardown()
+            )
+        );
+
+        $cleaner->cleanRegistered()->shouldHaveBeenCalled();
     }
 }


### PR DESCRIPTION
Currently if the master copy exists when the site is run but the `clean_up` setting is `true` (presumably was `false` on a previous run), the master copy is used and is left untouched. This removes it prior to the suite being run.
