### PR TITLE
Use --uri option instead of working directory

### DIFF
--- a/src/Listener/BypassInstallSiteListener.php
+++ b/src/Listener/BypassInstallSiteListener.php
@@ -114,8 +114,9 @@ final class BypassInstallSiteListener implements EventSubscriber
             ProcessBuilder::create()
                 ->setPrefix($this->binary)
                 ->add('sql-drop')
+                ->add('--uri=' . $this->drupal->getUri())
                 ->add('--yes')
-                ->setWorkingDirectory($this->drupal->getSitePath())
+                ->setWorkingDirectory($this->drupal->getPath())
                 ->setTimeout(null)
                 ->getProcess()
         );
@@ -126,8 +127,9 @@ final class BypassInstallSiteListener implements EventSubscriber
                 ->setPrefix($this->binary)
                 ->add('sql-query')
                 ->add('--file=' . $this->drupal->getSitePath() . '/db.sql')
+                ->add('--uri=' . $this->drupal->getUri())
                 ->add('--yes')
-                ->setWorkingDirectory($this->drupal->getSitePath())
+                ->setWorkingDirectory($this->drupal->getPath())
                 ->setTimeout(null)
                 ->getProcess()
         );
@@ -162,8 +164,9 @@ final class BypassInstallSiteListener implements EventSubscriber
                 ->setPrefix($this->binary)
                 ->add('sql-dump')
                 ->add('--result-file=' . $this->masterPath . '/db.sql')
+                ->add('--uri=' . $this->drupal->getUri())
                 ->add('--yes')
-                ->setWorkingDirectory($this->drupal->getSitePath())
+                ->setWorkingDirectory($this->drupal->getPath())
                 ->setTimeout(null)
                 ->getProcess()
         );

--- a/src/Listener/InstallSiteListener.php
+++ b/src/Listener/InstallSiteListener.php
@@ -73,7 +73,7 @@ final class InstallSiteListener implements EventSubscriber
             ->add('--account-name=admin')
             ->add('--account-pass=password')
             ->add('--yes')
-            ->setWorkingDirectory($this->drupal->getSitePath())
+            ->setWorkingDirectory($this->drupal->getPath())
             ->setTimeout(null)
             ->setEnv('PHP_OPTIONS', '-d sendmail_path=' . `which true`);
 

--- a/tests/Listener/BypassInstallSiteListenerTest.php
+++ b/tests/Listener/BypassInstallSiteListenerTest.php
@@ -62,7 +62,7 @@ final class BypassInstallSiteListenerTest extends ListenerTest
                 $process = $call->getArguments()[0];
 
                 Assert::assertSame(
-                    "'/path/to/drush' 'sql-dump' '--result-file=vfs://foo/sites/localhost.master/db.sql' '--yes'",
+                    "'/path/to/drush' 'sql-dump' '--result-file=vfs://foo/sites/localhost.master/db.sql' '--uri=http://localhost/' '--yes'",
                     $process->getCommandLine()
                 );
             }));
@@ -149,19 +149,19 @@ final class BypassInstallSiteListenerTest extends ListenerTest
                 $process1 = $calls[1]->getArguments()[0];
 
                 Assert::assertSame(
-                    "'/path/to/drush' 'sql-drop' '--yes'",
+                    "'/path/to/drush' 'sql-drop' '--uri=http://localhost/' '--yes'",
                     $process0->getCommandLine()
                 );
                 Assert::assertSame(
-                    $drupal->getSitePath(),
+                    $drupal->getPath(),
                     $process0->getWorkingDirectory()
                 );
                 Assert::assertSame(
-                    "'/path/to/drush' 'sql-query' '--file=vfs://foo/sites/localhost/db.sql' '--yes'",
+                    "'/path/to/drush' 'sql-query' '--file=vfs://foo/sites/localhost/db.sql' '--uri=http://localhost/' '--yes'",
                     $process1->getCommandLine()
                 );
                 Assert::assertSame(
-                    $drupal->getSitePath(),
+                    $drupal->getPath(),
                     $process1->getWorkingDirectory()
                 );
             }));

--- a/tests/Listener/InstallSiteListenerTest.php
+++ b/tests/Listener/InstallSiteListenerTest.php
@@ -39,7 +39,7 @@ final class InstallSiteListenerTest extends ListenerTest
                 Argument::type('eLife\IsolatedDrupalBehatExtension\Event\InstallingSite')
             )
             ->shouldBeCalledTimes(1)
-            ->should(new CallbackPrediction(function (array $calls) {
+            ->should(new CallbackPrediction(function (array $calls) use ($drupal) {
                 /** @var Call $call */
                 $call = $calls[0];
 
@@ -58,6 +58,10 @@ final class InstallSiteListenerTest extends ListenerTest
                 Assert::assertSame(
                     '-d sendmail_path=' . `which true`,
                     $process->getEnv()['PHP_OPTIONS']
+                );
+                Assert::assertSame(
+                    $drupal->getPath(),
+                    $process->getWorkingDirectory()
                 );
             }));
 


### PR DESCRIPTION
If the `sites` folder is a symlink, the Drush fails to connect to the database. Using the `--uri` option rather than setting the working directory to the site works.
