### PR TITLE
Make sure Drush executes on the test site

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "php": ">=5.4",
         "behat/behat": "^3.0.6",
         "behat/mink-extension": "~2.0",
+        "drupal/drupal-driver": "^1.0.1",
         "drupal/drupal-extension": "~3.0",
         "symfony/dependency-injection": "~2.5",
         "symfony/event-dispatcher": "~2.3",

--- a/features/drupal7.feature
+++ b/features/drupal7.feature
@@ -189,3 +189,68 @@ Feature: Isolated Drupal 7 runs
             2 scenarios (2 passed)
             10 steps (10 passed)
             """
+
+    Scenario: Drush does not execute on the main site
+        Given Drupal is installed
+        And the "site_name" variable is set to "My site"
+        And a file named "behat.yml" with:
+            """
+            default:
+                suites:
+                    default:
+                        contexts:
+                          - FeatureContext: ~
+                          - Drupal\DrupalExtension\Context\DrushContext: ~
+                          - Drupal\DrupalExtension\Context\RawDrupalContext: ~
+                extensions:
+                    Behat\MinkExtension:
+                        goutte: ~
+                        base_url: '{{ base_url }}'
+                    Drupal\DrupalExtension:
+                        blackbox: ~
+                        api_driver: 'drupal'
+                        drush:
+                            binary: '{{ drush }}'
+                            root: '{{ drupal_root }}'
+                        drupal:
+                            drupal_root: '{{ drupal_root }}'
+                    eLife\IsolatedDrupalBehatExtension:
+                        db_url: '{{ db_url }}'
+            """
+        And a file named "features/bootstrap/FeatureContext.php" with:
+            """
+            <?php
+
+            use Behat\Behat\Context\Context;
+
+            class FeatureContext implements Context
+            {
+                /**
+                 * @When the :arg1 variable is set to :arg2
+                 */
+                public function theVariableIsSetTo($variable, $value)
+                {
+                    variable_set($variable, $value);
+                }
+            }
+            """
+        And a file named "features/client.feature" with:
+            """
+            Feature: Setting the site name
+                In order to understand what site I am on
+                As a website user
+                I need to be able to see the site name
+
+            Scenario: Default name is Set
+                Given the "site_name" variable is set to "Foo"
+                When I run drush "variable-get --exact site_name"
+                Then drush output should contain "Foo"
+            """
+        When I run "behat --format progress features/client.feature"
+        Then it should pass with:
+            """
+            ...
+
+            1 scenario (1 passed)
+            3 steps (3 passed)
+            """

--- a/src/ServiceContainer/Compiler/DrushUriCompilerPass.php
+++ b/src/ServiceContainer/Compiler/DrushUriCompilerPass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace eLife\IsolatedDrupalBehatExtension\ServiceContainer\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface as CompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class DrushUriCompilerPass implements CompilerPass
+{
+    public function process(ContainerBuilder $container)
+    {
+        $container->setParameter('drupal.driver.drush.alias', null);
+        $container->setParameter(
+            'drupal.driver.drush.root',
+            '%drupal.driver.drupal.drupal_root%'
+        );
+
+        $container->getDefinition('drupal.driver.drush')
+            ->addMethodCall('setArguments', ['--uri=%mink.base_url%']);
+    }
+}

--- a/src/ServiceContainer/IsolatedDrupalBehatExtension.php
+++ b/src/ServiceContainer/IsolatedDrupalBehatExtension.php
@@ -4,6 +4,7 @@ namespace eLife\IsolatedDrupalBehatExtension\ServiceContainer;
 
 use Behat\Testwork\ServiceContainer\Extension as TestworkExtension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
+use eLife\IsolatedDrupalBehatExtension\ServiceContainer\Compiler\DrushUriCompilerPass;
 use eLife\IsolatedDrupalBehatExtension\ServiceContainer\Compiler\FilesystemCleanerCompilerPass;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\FileLocator;
@@ -79,6 +80,9 @@ final class IsolatedDrupalBehatExtension implements TestworkExtension
      */
     public function getCompilerPasses()
     {
-        return [new FilesystemCleanerCompilerPass()];
+        return [
+            new DrushUriCompilerPass(),
+            new FilesystemCleanerCompilerPass(),
+        ];
     }
 }

--- a/tests/ServiceContainer/Compiler/DrushUriCompilerPassTest.php
+++ b/tests/ServiceContainer/Compiler/DrushUriCompilerPassTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace eLife\IsolatedDrupalBehatExtension\ServiceContainer;
+
+use Drupal\Driver\DrushDriver;
+use eLife\IsolatedDrupalBehatExtension\ServiceContainer\Compiler\DrushUriCompilerPass;
+use eLife\IsolatedDrupalBehatExtension\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class DrushUriCompilerPassTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itCleansTheFilesystem()
+    {
+        $compilerPass = new DrushUriCompilerPass();
+
+        $container = new ContainerBuilder();
+        $container->setParameter('mink.base_url', 'http://localhost/');
+        $container->setParameter('drupal.driver.drush.alias', 'foo');
+        $container->setParameter('drupal.driver.drush.root', __DIR__ . '/../');
+        $container->setParameter('drupal.driver.drupal.drupal_root', __DIR__);
+        $container->setDefinition(
+            'drupal.driver.drush',
+            new Definition('Drupal\Driver\DrushDriver', [
+                '%drupal.driver.drush.alias%',
+                '%drupal.driver.drush.root%',
+            ])
+        );
+
+        $compilerPass->process($container);
+
+        $container->compile();
+
+        /** @var DrushDriver $drush */
+        $drush = $container->get('drupal.driver.drush');
+
+        $this->assertNull($drush->alias);
+        $this->assertSame(__DIR__, $drush->root);
+        $this->assertSame('--uri=http://localhost/', $drush->getArguments());
+    }
+}

--- a/tests/ServiceContainer/IsolatedDrupalBehatExtensionTest.php
+++ b/tests/ServiceContainer/IsolatedDrupalBehatExtensionTest.php
@@ -6,6 +6,7 @@ use Behat\Testwork\ServiceContainer\ExtensionManager;
 use eLife\IsolatedDrupalBehatExtension\TestCase;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 final class IsolatedDrupalBehatExtensionTest extends TestCase
 {
@@ -36,7 +37,13 @@ final class IsolatedDrupalBehatExtensionTest extends TestCase
     {
         $extension = new IsolatedDrupalBehatExtension();
 
-        $extension->process(new ContainerBuilder());
+        $container = new ContainerBuilder();
+        $container->setDefinition(
+            'drupal.driver.drush',
+            new Definition('Drupal\Driver\DrushDriver')
+        );
+
+        $extension->process($container);
     }
 
     /**


### PR DESCRIPTION
Currently Drush will execute on the main site rather than the test one if the user hasn't set their DrupalExtension configuration to be aware of this extension. This overrides it (ie removes the site alias and normalises the root) and forces the `DrushDriver` to use the `--uri` option, which should mean that all commands execute on the test site.
