### PR TITLE
Prevent a superfluous copy before the suite is run

### DIFF
--- a/src/Listener/BypassInstallSiteListener.php
+++ b/src/Listener/BypassInstallSiteListener.php
@@ -2,6 +2,7 @@
 
 namespace eLife\IsolatedDrupalBehatExtension\Listener;
 
+use Behat\Testwork\EventDispatcher\Event\BeforeSuiteTested;
 use Behat\Testwork\EventDispatcher\Event\SuiteTested;
 use eLife\IsolatedDrupalBehatExtension\Drupal;
 use eLife\IsolatedDrupalBehatExtension\Event\SiteCloned;
@@ -94,9 +95,14 @@ final class BypassInstallSiteListener implements EventSubscriber
         $this->lazyFilesystemCleaner = $lazyFilesystemCleaner;
     }
 
-    public function onBeforeSuite()
+    public function onBeforeSuite(BeforeSuiteTested $event)
     {
         $this->filesystemCleaner->clean([$this->masterPath]);
+
+        if (is_dir($this->drupal->getSitePath())) {
+            // The site exists, it doesn't need to be installed at this point.
+            $event->stopPropagation();
+        }
     }
 
     public function onInstallingSite(InstallingSite $event)


### PR DESCRIPTION
The install process has to be run on `SuiteTested::BEFORE` as the DrupalExtension bootstraps the site at this point; currently `BypassInstallSiteListener` listener will copy in the test site, then do it again for the first scenario. If the site already exists (ie the `clean_up` setting is `false`), there's no need to do it the first time, so this stops it.
