### PR TITLE
puts single quotes around scalars containing '@'

### DIFF
--- a/src/ServiceContainer/config/filesystem.yml
+++ b/src/ServiceContainer/config/filesystem.yml
@@ -9,7 +9,7 @@ services:
     decorates: elife.isolated_drupal_behat.filesystem_cleaner
     public: false
     arguments:
-      - @elife.isolated_drupal_behat.symfony_filesystem
+      - '@elife.isolated_drupal_behat.symfony_filesystem'
 
   elife.isolated_drupal_behat.filesystem_cleaner.no_op:
     class: eLife\IsolatedDrupalBehatExtension\Filesystem\NoOpFilesystemCleaner
@@ -24,4 +24,4 @@ services:
     decorates: elife.isolated_drupal_behat.lazy_filesystem_cleaner
     public: false
     arguments:
-      - @elife.isolated_drupal_behat.filesystem_cleaner
+      - '@elife.isolated_drupal_behat.filesystem_cleaner'

--- a/src/ServiceContainer/config/listeners.yml
+++ b/src/ServiceContainer/config/listeners.yml
@@ -3,37 +3,37 @@ services:
   elife.isolated_drupal_behat.listener.install_site:
     class: eLife\IsolatedDrupalBehatExtension\Listener\InstallSiteListener
     arguments:
-      - @event_dispatcher
-      - @elife.isolated_drupal_behat.drupal
+      - '@event_dispatcher'
+      - '@elife.isolated_drupal_behat.drupal'
       - %drupal.driver.drush.binary%
-      - @elife.isolated_drupal_behat.process_runner
+      - '@elife.isolated_drupal_behat.process_runner'
     tags:
       - { name: event_dispatcher.subscriber }
 
   elife.isolated_drupal_behat.listener.bypass_install_site:
     class: eLife\IsolatedDrupalBehatExtension\Listener\BypassInstallSiteListener
     arguments:
-      - @event_dispatcher
-      - @elife.isolated_drupal_behat.drupal
-      - @elife.isolated_drupal_behat.symfony_filesystem
+      - '@event_dispatcher'
+      - '@elife.isolated_drupal_behat.drupal'
+      - '@elife.isolated_drupal_behat.symfony_filesystem'
       - %drupal.driver.drush.binary%
-      - @elife.isolated_drupal_behat.process_runner
-      - @elife.isolated_drupal_behat.filesystem_cleaner
-      - @elife.isolated_drupal_behat.lazy_filesystem_cleaner
+      - '@elife.isolated_drupal_behat.process_runner'
+      - '@elife.isolated_drupal_behat.filesystem_cleaner'
+      - '@elife.isolated_drupal_behat.lazy_filesystem_cleaner'
     tags:
       - { name: event_dispatcher.subscriber }
 
   elife.isolated_drupal_behat.listener.cleaner:
     class: eLife\IsolatedDrupalBehatExtension\Listener\CleanerListener
     arguments:
-      - @elife.isolated_drupal_behat.lazy_filesystem_cleaner
+      - '@elife.isolated_drupal_behat.lazy_filesystem_cleaner'
     tags:
       - { name: event_dispatcher.subscriber }
 
   elife.isolated_drupal_behat.listener.settings:
     class: eLife\IsolatedDrupalBehatExtension\Listener\WriteSettingsFileListener
     arguments:
-      - @event_dispatcher
-      - @elife.isolated_drupal_behat.symfony_filesystem
+      - '@event_dispatcher'
+      - '@elife.isolated_drupal_behat.symfony_filesystem'
     tags:
       - { name: event_dispatcher.subscriber }

--- a/src/ServiceContainer/config/listeners_settings_file.yml
+++ b/src/ServiceContainer/config/listeners_settings_file.yml
@@ -22,13 +22,13 @@ services:
   elife.isolated_drupal_behat.listener.settings.hash_salt:
     class: eLife\IsolatedDrupalBehatExtension\Listener\SettingsFile\HashSaltSettingsFileListener
     arguments:
-      - @elife.isolated_drupal_behat.random_string_generator
+      - '@elife.isolated_drupal_behat.random_string_generator'
     tags:
       - { name: event_dispatcher.subscriber }
 
   elife.isolated_drupal_behat.listener.settings.file_path:
     class: eLife\IsolatedDrupalBehatExtension\Listener\SettingsFile\FilePathSettingsFileListener
     arguments:
-      - @elife.isolated_drupal_behat.random_string_generator
+      - '@elife.isolated_drupal_behat.random_string_generator'
     tags:
       - { name: event_dispatcher.subscriber }

--- a/src/ServiceContainer/config/random_string_generators.yml
+++ b/src/ServiceContainer/config/random_string_generators.yml
@@ -9,13 +9,13 @@ services:
     decorates: elife.isolated_drupal_behat.random_string_generator
     public: false
     arguments:
-      - @elife.isolated_drupal_behat.random_string_generator.limiting
+      - '@elife.isolated_drupal_behat.random_string_generator.limiting'
 
   elife.isolated_drupal_behat.random_string_generator.limiting:
     class: eLife\IsolatedDrupalBehatExtension\RandomString\LimitingRandomStringGenerator
     public: false
     arguments:
-      - @elife.isolated_drupal_behat.random_string_generator.hash
+      - '@elife.isolated_drupal_behat.random_string_generator.hash'
       - 10
 
   elife.isolated_drupal_behat.random_string_generator.hash:


### PR DESCRIPTION
In Symfony 3 strings containing a number of special characters need to be quoted.
